### PR TITLE
pull in latest upstream changes from analytics-swift-appsflyer

### DIFF
--- a/Example/BasicExample/BasicExample.xcodeproj/project.pbxproj
+++ b/Example/BasicExample/BasicExample.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		46EDC70727C6B8D200B870D7 /* BasicExampleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EDC70627C6B8D200B870D7 /* BasicExampleTests.swift */; };
 		46EDC71127C6B8D200B870D7 /* BasicExampleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EDC71027C6B8D200B870D7 /* BasicExampleUITests.swift */; };
 		46EDC71327C6B8D200B870D7 /* BasicExampleUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46EDC71227C6B8D200B870D7 /* BasicExampleUITestsLaunchTests.swift */; };
+		829478832BC5DC810066FC81 /* AppsFlyerLib-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = 829478822BC5DC810066FC81 /* AppsFlyerLib-Dynamic */; };
 		EA64AC7329D31296009F2F53 /* Segment in Frameworks */ = {isa = PBXBuildFile; productRef = EA64AC7229D31296009F2F53 /* Segment */; };
 		EA64AC7529D3129A009F2F53 /* SegmentAppsFlyer in Frameworks */ = {isa = PBXBuildFile; productRef = EA64AC7429D3129A009F2F53 /* SegmentAppsFlyer */; };
 /* End PBXBuildFile section */
@@ -53,6 +54,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				829478832BC5DC810066FC81 /* AppsFlyerLib-Dynamic in Frameworks */,
 				EA64AC7329D31296009F2F53 /* Segment in Frameworks */,
 				EA64AC7529D3129A009F2F53 /* SegmentAppsFlyer in Frameworks */,
 			);
@@ -158,6 +160,7 @@
 			packageProductDependencies = (
 				EA64AC7229D31296009F2F53 /* Segment */,
 				EA64AC7429D3129A009F2F53 /* SegmentAppsFlyer */,
+				829478822BC5DC810066FC81 /* AppsFlyerLib-Dynamic */,
 			);
 			productName = BasicExample;
 			productReference = 46EDC6F227C6B8D100B870D7 /* BasicExample.app */;
@@ -233,6 +236,7 @@
 			mainGroup = 46EDC6E927C6B8D100B870D7;
 			packageReferences = (
 				46EDC71F27C6B92C00B870D7 /* XCRemoteSwiftPackageReference "analytics-swift" */,
+				829478812BC5DC800066FC81 /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Dynamic" */,
 			);
 			productRefGroup = 46EDC6F327C6B8D100B870D7 /* Products */;
 			projectDirPath = "";
@@ -608,9 +612,22 @@
 				minimumVersion = 1.1.2;
 			};
 		};
+		829478812BC5DC800066FC81 /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Dynamic" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 6.14.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		829478822BC5DC810066FC81 /* AppsFlyerLib-Dynamic */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 829478812BC5DC800066FC81 /* XCRemoteSwiftPackageReference "AppsFlyerFramework-Dynamic" */;
+			productName = "AppsFlyerLib-Dynamic";
+		};
 		EA64AC7229D31296009F2F53 /* Segment */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 46EDC71F27C6B92C00B870D7 /* XCRemoteSwiftPackageReference "analytics-swift" */;

--- a/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/segmentio/analytics-swift",
         "state": {
           "branch": null,
-          "revision": "efc111b5fccaebd1063ef0db6d206c252da387ec",
-          "version": "1.4.8"
+          "revision": "33f07bd5e4d216de92a163a8edad2c3216087cd9",
+          "version": "1.5.5"
         }
       },
       {
@@ -15,17 +15,26 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
         "state": {
           "branch": null,
-          "revision": "fd2d4e50107280229c77ebfaeb0519ad7e7af83f",
-          "version": "6.10.0"
+          "revision": "4591cd113ea1af6fa950479fadbce2f13bab8895",
+          "version": "6.13.1"
+        }
+      },
+      {
+        "package": "JSONSafeEncoder",
+        "repositoryURL": "https://github.com/segmentio/jsonsafeencoder-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
+          "version": "1.0.1"
         }
       },
       {
         "package": "Sovran",
-        "repositoryURL": "https://github.com/segmentio/Sovran-Swift.git",
+        "repositoryURL": "https://github.com/segmentio/sovran-swift.git",
         "state": {
           "branch": null,
-          "revision": "64f3b5150c282a34af4578188dce2fd597e600e3",
-          "version": "1.1.0"
+          "revision": "a342b905f6baa64499cabdf61ccc185ec476b7b2",
+          "version": "1.1.1"
         }
       }
     ]

--- a/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,17 +6,26 @@
         "repositoryURL": "https://github.com/segmentio/analytics-swift",
         "state": {
           "branch": null,
-          "revision": "efc111b5fccaebd1063ef0db6d206c252da387ec",
-          "version": "1.4.8"
+          "revision": "7eeb2abf8452153af056baae5369679589f10936",
+          "version": "1.5.9"
         }
       },
       {
         "package": "AppsFlyerLib",
-        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
+        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
         "state": {
           "branch": null,
-          "revision": "fd2d4e50107280229c77ebfaeb0519ad7e7af83f",
-          "version": "6.10.0"
+          "revision": "0cdea50ab90d9bd63645d2d51bcef5850ca4aa9f",
+          "version": "6.14.0"
+        }
+      },
+      {
+        "package": "JSONSafeEncoder",
+        "repositoryURL": "https://github.com/segmentio/jsonsafeencoder-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/segmentio/Sovran-Swift.git",
         "state": {
           "branch": null,
-          "revision": "64f3b5150c282a34af4578188dce2fd597e600e3",
-          "version": "1.1.0"
+          "revision": "a342b905f6baa64499cabdf61ccc185ec476b7b2",
+          "version": "1.1.1"
         }
       }
     ]

--- a/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/BasicExample/BasicExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/segmentio/analytics-swift",
         "state": {
           "branch": null,
-          "revision": "33f07bd5e4d216de92a163a8edad2c3216087cd9",
-          "version": "1.5.5"
+          "revision": "efc111b5fccaebd1063ef0db6d206c252da387ec",
+          "version": "1.4.8"
         }
       },
       {
@@ -15,26 +15,17 @@
         "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
         "state": {
           "branch": null,
-          "revision": "4591cd113ea1af6fa950479fadbce2f13bab8895",
-          "version": "6.13.1"
-        }
-      },
-      {
-        "package": "JSONSafeEncoder",
-        "repositoryURL": "https://github.com/segmentio/jsonsafeencoder-swift.git",
-        "state": {
-          "branch": null,
-          "revision": "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
-          "version": "1.0.1"
+          "revision": "fd2d4e50107280229c77ebfaeb0519ad7e7af83f",
+          "version": "6.10.0"
         }
       },
       {
         "package": "Sovran",
-        "repositoryURL": "https://github.com/segmentio/sovran-swift.git",
+        "repositoryURL": "https://github.com/segmentio/Sovran-Swift.git",
         "state": {
           "branch": null,
-          "revision": "a342b905f6baa64499cabdf61ccc185ec476b7b2",
-          "version": "1.1.1"
+          "revision": "64f3b5150c282a34af4578188dce2fd597e600e3",
+          "version": "1.1.0"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,17 +6,26 @@
         "repositoryURL": "https://github.com/segmentio/analytics-swift.git",
         "state": {
           "branch": null,
-          "revision": "79fb17a5d4abf8f80e6a0935e57c7df7b670a6c0",
-          "version": "1.4.1"
+          "revision": "7eeb2abf8452153af056baae5369679589f10936",
+          "version": "1.5.9"
         }
       },
       {
         "package": "AppsFlyerLib",
-        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
+        "repositoryURL": "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
         "state": {
           "branch": null,
-          "revision": "096dfa446caae0b92d6dd00486a6178a6ffd9ad9",
-          "version": "6.10.1"
+          "revision": "0cdea50ab90d9bd63645d2d51bcef5850ca4aa9f",
+          "version": "6.14.0"
+        }
+      },
+      {
+        "package": "JSONSafeEncoder",
+        "repositoryURL": "https://github.com/segmentio/jsonsafeencoder-swift.git",
+        "state": {
+          "branch": null,
+          "revision": "8b70dc8c01b7b041912e30e29d2b488a43f782ac",
+          "version": "1.0.1"
         }
       },
       {
@@ -24,8 +33,8 @@
         "repositoryURL": "https://github.com/segmentio/Sovran-Swift.git",
         "state": {
           "branch": null,
-          "revision": "944c17d7c46bd95fc37f09136cabd172be5b413b",
-          "version": "1.0.3"
+          "revision": "a342b905f6baa64499cabdf61ccc185ec476b7b2",
+          "version": "1.1.1"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,12 @@ let package = Package(
         .package(
             name: "Segment",
             url: "https://github.com/segmentio/analytics-swift.git",
-            from: "1.5.5"
+            from: "1.5.9"
         ),
         .package(
-            name: "AppsFlyerLib",
-            url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
-            from: "6.13.1"
+            name: "AppsFlyerLib-Dynamic",
+            url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework-Dynamic",
+            from: "6.14.0"
         )
     ],
     targets: [
@@ -35,7 +35,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SegmentAppsFlyer",
-            dependencies: ["Segment", "AppsFlyerLib"]),
+            dependencies: ["Segment", "AppsFlyerLib-Dynamic"]),
         
         // TESTS ARE HANDLED VIA THE EXAMPLE APP.
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -22,12 +22,12 @@ let package = Package(
         .package(
             name: "Segment",
             url: "https://github.com/segmentio/analytics-swift.git",
-            from: "1.4.1"
+            from: "1.5.5"
         ),
         .package(
             name: "AppsFlyerLib",
             url: "https://github.com/AppsFlyerSDK/AppsFlyerFramework",
-            from: "6.10.0"
+            from: "6.13.1"
         )
     ],
     targets: [

--- a/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
+++ b/Sources/SegmentAppsFlyer/AppsFlyerDestination.swift
@@ -213,12 +213,10 @@ extension AppsFlyerDestination: AppsFlyerLibDelegate {
                         "name": campaign,
                         "ad_group": adgroup
                     ]
-                    let campaignStr = (campaign.compactMap({ (key, value) -> String in
-                        return "\(key)=\(value)"
-                    }) as Array).joined(separator: ";")
+
                     let properties: [String: Codable] = [
                         "provider": "AppsFlyer",
-                        "campaign": campaignStr
+                        "campaign": try? JSON(campaign)
                     ]
                     analytics?.track(name: "Install Attributed", properties: properties)
                     

--- a/Sources/SegmentAppsFlyer/Version.swift
+++ b/Sources/SegmentAppsFlyer/Version.swift
@@ -13,4 +13,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __destination_version = "1.1.6"
+internal let __destination_version = "1.1.7"

--- a/Sources/SegmentAppsFlyer/Version.swift
+++ b/Sources/SegmentAppsFlyer/Version.swift
@@ -13,4 +13,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __destination_version = "1.1.5"
+internal let __destination_version = "1.1.6"

--- a/Sources/SegmentAppsFlyer/Version.swift
+++ b/Sources/SegmentAppsFlyer/Version.swift
@@ -13,4 +13,4 @@
 // Use release.sh's automation.
 
 // BREAKING.FEATURE.FIX
-internal let __destination_version = "1.1.7"
+internal let __destination_version = "1.1.8"


### PR DESCRIPTION
This pulls down the latest changes from the upstream repo. This is to allow for building with newer versions of Xcode (than currently) and allows other repositories (like analytic-ios) to also upgrade to more recent versions of needed dependencies. 

Changes are:
- Using a new version of the AppsFlyer library itself, it's now named "AppsFlyerLib-Dynamic" (this is to resolve a build error with Xcode 15.3)
- Upgrades the minimum analytics-swift library to 1.5.9
- small change to how `campaign` value is encoded.